### PR TITLE
Release 2/sps

### DIFF
--- a/features/sps/process.feature
+++ b/features/sps/process.feature
@@ -9,7 +9,21 @@ Feature: Science Processing Service
 
   Scenario: Undeploy an Algorithm deployment
 
+  Scenario: List deployed WPS Processes
+    Given the SoundsSIPS L1A algorithm has been deployed to the ADES
+    And the SoundsSIPS L1B algorithm has been deployed to the ADES
+    When GetCapabilities is called on the WPS-T endpoint
+    Then the WPS-T response is an http-200 Status
+    And the response includes process summary elements
+    And the process summary included the L1A and L1B processors
+
   Scenario: Get the inputs for a given Algorithm deployment
+    Given the SoundsSIPS L1A algorithm has been deployed to the ADES
+    When DescribeProcess is called on the WPS-T endpoint for the L1A Algorithm
+    Then the WPS-T endpoint responds with a ProcessOfferings response
+    And the response page returns a HTTP 200
+    And the response page includes the one or more input element
+    # more to add here?
 
   Scenario: Request L1A Processing from an Algorithm deployment
     Given the SoundsSIPS L1A algorithm has been deployed to the ADES
@@ -24,12 +38,12 @@ Feature: Science Processing Service
     And SounderSIPS L1A data exists in the Unity system
     When a WPS-T request is made to execute the job and the defined L1A Data
     Then a WPS-T response includes a 302
-    And the response redirects users to a job status page
-    And the job status page returns a HTTP 200
-    And the job status processing status is one of "PENDING", "IN PROGRESS", or "COMPLETE"
+    And the response redirects users to an OGC StatusInfo page
+    And the response page returns a HTTP 200
+    And the OGC StatusInfo processing status is one of "Succeeded", "Failed", "Accepted", or "Running"
 
   Scenario: Get the result of a process request
     Given a job processing id for L0 to L1A processing Request
     When a user queries the WPS-T for the given job Id
     Then the job status page returns a HTTP 200
-    And the job status processing status is one of "PENDING", "IN PROGRESS", or "COMPLETE"
+    And the OGC StatusInfo processing status is one of "Succeeded", "Failed", "Accepted", or "Running"

--- a/features/sps/process.feature
+++ b/features/sps/process.feature
@@ -2,10 +2,10 @@
 Feature: Science Processing Service
   The ADES is fronted by a WPS-T service which allows for the deployment and
   undeployment of application packages. It also allows for the exectuion,
-  status, and retrievel of job submissions. This is captured in the zenhub epic
+  status, and retrieval of job submissions. This is captured in the zenhub epic
   at https://app.zenhub.com/workspaces/unity-workspace-61d4b6a48ed26b001d7d184a/issues/unity-sds/unity-sps-prototype/57
 
-  Scenario: Request an Aglorithm Deployment
+  Scenario: Request an Algorithm Deployment
 
   Scenario: Undeploy an Algorithm deployment
 
@@ -29,17 +29,20 @@ Feature: Science Processing Service
     Given the SoundsSIPS L1A algorithm has been deployed to the ADES
     And SounderSIPS L0 data exists for a 2 hour block of Data in the Unity system
     When a WPS-T request is made to execute the job and the defined L0 Data
-    Then a WPS-T response includes a 302
-    And the response redirects users to a job status page
-    And the response redirection includes job processing status
+    Then a WPS-T response is a 201
+    And the response include a Location header
+    And the Location header directs users to an OGC StatusInfo page
+    And the OGC StatusInfo page returns a HTTP 200
+    And the OGC StatusInfo processing status is one of "Succeeded", "Failed", "Accepted", or "Running"
 
   Scenario: Request L1B Processing from an Algorithm deployment
     Given the SoundsSIPS L1B algorithm has been deployed to the ADES
     And SounderSIPS L1A data exists in the Unity system
     When a WPS-T request is made to execute the job and the defined L1A Data
-    Then a WPS-T response includes a 302
-    And the response redirects users to an OGC StatusInfo page
-    And the response page returns a HTTP 200
+    Then a WPS-T response is a 201
+    And the response include a Location header
+    And the Location header directs users to an OGC StatusInfo page
+    And the OGC StatusInfo page returns a HTTP 200
     And the OGC StatusInfo processing status is one of "Succeeded", "Failed", "Accepted", or "Running"
 
   Scenario: Get the result of a process request

--- a/features/sps/process.feature
+++ b/features/sps/process.feature
@@ -21,8 +21,8 @@ Feature: Science Processing Service
     Given the SoundsSIPS L1A algorithm has been deployed to the ADES
     When DescribeProcess is called on the WPS-T endpoint for the L1A Algorithm
     Then the WPS-T endpoint responds with a ProcessOfferings response
-    And the response page returns a HTTP 200
-    And the response page includes the one or more input element
+    And the response returns an HTTP 200
+    And the response includes the one or more input element
     # more to add here?
 
   Scenario: Request L1A Processing from an Algorithm deployment
@@ -30,9 +30,9 @@ Feature: Science Processing Service
     And SounderSIPS L0 data exists for a 2 hour block of Data in the Unity system
     When a WPS-T request is made to execute the job and the defined L0 Data
     Then a WPS-T response is a 201
-    And the response include a Location header
-    And the Location header directs users to an OGC StatusInfo page
-    And the OGC StatusInfo page returns a HTTP 200
+    And the response includes a Location header
+    And the Location header directs users to an OGC StatusInfo document
+    And the OGC StatusInfo document returns a HTTP 200
     And the OGC StatusInfo processing status is one of "Succeeded", "Failed", "Accepted", or "Running"
 
   Scenario: Request L1B Processing from an Algorithm deployment
@@ -40,13 +40,13 @@ Feature: Science Processing Service
     And SounderSIPS L1A data exists in the Unity system
     When a WPS-T request is made to execute the job and the defined L1A Data
     Then a WPS-T response is a 201
-    And the response include a Location header
-    And the Location header directs users to an OGC StatusInfo page
-    And the OGC StatusInfo page returns a HTTP 200
+    And the response includes a Location header
+    And the Location header directs users to an OGC StatusInfo document
+    And the OGC StatusInfo document returns a HTTP 200
     And the OGC StatusInfo processing status is one of "Succeeded", "Failed", "Accepted", or "Running"
 
   Scenario: Get the result of a process request
-    Given a job processing id for L0 to L1A processing Request
+    Given a job processing id for a processing Request
     When a user queries the WPS-T for the given job Id
-    Then the job status page returns a HTTP 200
+    Then the response returns an HTTP 200
     And the OGC StatusInfo processing status is one of "Succeeded", "Failed", "Accepted", or "Running"

--- a/features/sps/process.feature
+++ b/features/sps/process.feature
@@ -1,4 +1,9 @@
+
 Feature: Science Processing Service
+  The ADES is fronted by a WPS-T service which allows for the deployment and
+  undeployment of application packages. It also allows for the exectuion,
+  status, and retrievel of job submissions. This is captured in the zenhub epic
+  at https://app.zenhub.com/workspaces/unity-workspace-61d4b6a48ed26b001d7d184a/issues/unity-sds/unity-sps-prototype/57
 
   Scenario: Request an Aglorithm Deployment
 
@@ -6,6 +11,25 @@ Feature: Science Processing Service
 
   Scenario: Get the inputs for a given Algorithm deployment
 
-  Scenario: Request Processing from an Algorithm deployment
+  Scenario: Request L1A Processing from an Algorithm deployment
+    Given the SoundsSIPS L1A algorithm has been deployed to the ADES
+    And SounderSIPS L0 data exists for a 2 hour block of Data in the Unity system
+    When a WPS-T request is made to execute the job and the defined L0 Data
+    Then a WPS-T response includes a 302
+    And the response redirects users to a job status page
+    And the response redirection includes job processing status
+
+  Scenario: Request L1B Processing from an Algorithm deployment
+    Given the SoundsSIPS L1B algorithm has been deployed to the ADES
+    And SounderSIPS L1A data exists in the Unity system
+    When a WPS-T request is made to execute the job and the defined L1A Data
+    Then a WPS-T response includes a 302
+    And the response redirects users to a job status page
+    And the job status page returns a HTTP 200
+    And the job status processing status is one of "PENDING", "IN PROGRESS", or "COMPLETE"
 
   Scenario: Get the result of a process request
+    Given a job processing id for L0 to L1A processing Request
+    When a user queries the WPS-T for the given job Id
+    Then the job status page returns a HTTP 200
+    And the job status processing status is one of "PENDING", "IN PROGRESS", or "COMPLETE"


### PR DESCRIPTION
Draft PR for defining SounderSIPS based tests on WPS-T endpoints.

Missing:
* GetResults
* Deploy/Undeploy
* Cancel
* Non-nominal states (e.g. error handling)

@anilnatha and @rtapella i've added you as reviewers so you can start to see how the test cases will directly relate to the jupyter notebook work you need to do. This is not 'implementation spec' yet, we need buy-in from the developers before we can code to this, but i think these qualify as heuristics for the work to be done in the current form